### PR TITLE
Documentation Revision - 15th October | Fix minor errors in changes.md and index.md

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,11 +1,11 @@
 # Change log
 
-##### Revision 2022-10-14'
+##### Revision 2022-10-14
 - libc::printf replaced with io::printf
 
 ##### Revision 2022-10-01
 - Expanded and updated [types](../types).
-- 
+
 ##### Revision 2022-07-20
 - Added start + len syntax
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ It has evolved significantly, not just in syntax but also in regard to error han
 
 The C3 compiler can be found on github: [https://github.com/c3lang/c3c](https://github.com/c3lang/c3c).
 
-Last updated: [Revision 2022-10-01](changes).
+Last updated: [Revision 2022-10-14](changes).
 
 ## Features
 


### PR DESCRIPTION
changes.md:
- Remove unnecessary apostrophe behind Revision 2022-10-14
- Remove unnecessary bullet point in Revision 2022-10-01 that caused text to enlarge

index.md:
- Change revision date to reflect recent documentation changes.