### PR TITLE
Added Q&A for how to link to external C libraries via the project.json file

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -172,6 +172,22 @@ indicate its actual external name. For example, the function `int *ABC(void *x)`
 
 There are many examples of this in the `std::os` modules.
 
+**Q:** How do I link to external c libraries via the project.json?
+
+**A:** Add the `linked-libraries` and `linker-search-paths` properties to your `project.json`
+
+```json
+{
+  "linked-libraries": [
+    "glfw3",
+    "Gdi32"
+  ],
+  "linker-search-paths": [
+    "lib/windows-x64"
+  ]
+}
+```
+
 ## Patterns
 
 **Q:** When do I put functionality in method and when is it a free function?


### PR DESCRIPTION
As title states. Added a Q&A for how to link external C libraries via the project.json file by adding linked-libraries and linker-search-paths properties

I've placed it under the `Interfacing with C code` section